### PR TITLE
Add config unset and list commands with format support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "commands": [
             "config",
             "config set",
-            "config get"
+            "config get",
+            "config unset"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
             "config",
             "config set",
             "config get",
-            "config unset"
+            "config unset",
+            "config list"
         ]
     }
 }

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -72,4 +72,32 @@ class Config_Command extends EE_Command {
 
 		$this->fs->dumpFile( $config_file_path, Spyc::YAMLDump( $config, false, false, true ) );
 	}
+
+	/**
+	 * Unset a config value
+	 *
+	 * ## OPTIONS
+	 *
+	 * <key>
+	 * : Key of config to unset
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Remove value from config
+	 *     $ ee config unset cloudflare-api-key
+	 *
+	 */
+	public function unset( $args, $assoc_args ) {
+		$config_file_path = getenv( 'EE_CONFIG_PATH' ) ? getenv( 'EE_CONFIG_PATH' ) : EE_ROOT_DIR . '/config/config.yml';
+		$config           = Spyc::YAMLLoad( $config_file_path );
+		$key              = $args[0];
+
+		if ( ! isset( $config[ $key ] ) ) {
+			EE::error( "No config value with key '$key' set" );
+		}
+
+		unset( $config[ $key ] );
+
+		$this->fs->dumpFile( $config_file_path, Spyc::YAMLDump( $config, false, false, true ) );
+	}
 }

--- a/src/Config_Command.php
+++ b/src/Config_Command.php
@@ -100,4 +100,60 @@ class Config_Command extends EE_Command {
 
 		$this->fs->dumpFile( $config_file_path, Spyc::YAMLDump( $config, false, false, true ) );
 	}
+
+	/**
+	 * Lists the config values.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - yaml
+	 *   - json
+	 *   - count
+	 *   - text
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # List all config values
+	 *     $ ee config list
+	 *
+	 *     # List all config values in JSON
+	 *     $ ee config list --format=json
+	 *
+	 * @subcommand list
+	 */
+	public function _list( $args, $assoc_args ) {
+		$config_file_path = getenv( 'EE_CONFIG_PATH' ) ? getenv( 'EE_CONFIG_PATH' ) : EE_ROOT_DIR . '/config/config.yml';
+		$config           = Spyc::YAMLLoad( $config_file_path );
+		$format           = \EE\Utils\get_flag_value( $assoc_args, 'format' );
+
+		if ( empty( $config ) ) {
+			\EE::error( 'No config values found!' );
+		}
+
+		if ( 'text' === $format ) {
+			foreach ( $config as $key => $value ) {
+				\EE::log( $key . ': ' . $value );
+			}
+		} else {
+			$result = array_map(
+				function ( $key, $value ) {
+					return [
+						'key'   => $key,
+						'value' => $value,
+					];
+				},
+				array_keys( $config ),
+				$config
+			);
+
+			$formatter = new \EE\Formatter( $assoc_args, [ 'key', 'value' ] );
+			$formatter->display_items( $result );
+		}
+	}
 }


### PR DESCRIPTION
This pull request adds new functionality to the configuration command system, expanding the available options for managing configuration values. The main changes introduce the ability to unset and list configuration values via new subcommands, and update the command registration accordingly.

Closes: https://github.com/EasyEngine/config-command/issues/3

**New configuration command features:**

* Added `config unset` command to allow users to remove a configuration value by key.
* Added `config list` command to display all configuration values, supporting multiple output formats such as table, csv, yaml, json, count, and text.
* Updated the list of recognized commands in `composer.json` to include `config unset` and `config list`.